### PR TITLE
Fix for #24 & relative time

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "hubot-scripts": "^2.17.2",
     "hubot-shipit": "^0.2.0",
     "time": "^0.11.4",
-    "pug": "*"
+    "pug": "*",
+    "moment": "^2.17.1"
   },
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
Fixed the issue mentioned in #24 - turns out some of the variables were incorrectly named. Tested out relative time as well and there seems to be a problem with timeago, so I switched over to moment. Also made using relative time the default option instead of absolute time.