### PR TITLE
Implement auto-voicing in greeting.coffee

### DIFF
--- a/scripts/greeting.coffee
+++ b/scripts/greeting.coffee
@@ -12,6 +12,8 @@
 module.exports = (robot) ->
   # IRC nickname of the bot
   bot_nick = process.env.HUBOT_IRC_NICK
+  bot_rooms = process.env.HUBOT_IRC_ROOMS
+  main_bot_room = (bot_rooms.split ",")[0]
   # regexp for Guest nicknames
   guest_nick = /^(Guest|Terasologist)\d*$/i
   # greeting message sent to users
@@ -24,7 +26,7 @@ module.exports = (robot) ->
                  "Do check out https://github.com/MovingBlocks/Terasology/wiki/Using-IRC for more details about our IRC channel.\n" +
                  "If you would like to learn more about Terasology, be sure to visit http://forum.terasology.org for our forums " +
                  "and http://github.com/MovingBlocks/Terasology for our Github repo!\n"
-  understood_msg = "Reply 'Understood' if you do not want to receive this greeting again."
+  understood_msg = "Reply 'Understood' to gain voice. You will not receive this greeting again."
 
   robot.respond /understood.*/i, (msg) ->
     opt_out = JSON.parse(robot.brain.get 'greeting') or []
@@ -35,7 +37,8 @@ module.exports = (robot) ->
         opt_out.push username
         robot.brain.set('greeting', JSON.stringify(opt_out))
         robot.brain.save()
-        msg.send "You will not receive this greeting anymore. Message 'Reset Greeting' to me in private if you would like to undo this."
+        robot.adapter.command('MODE', main_bot_room, '+v', username)
+        msg.send "You have been given voice and will not receive this greeting anymore. Message 'Reset Greeting' to me in private if you would like to undo this."
       else if guest_nick.test(username)
         msg.send "Guest accounts cannot opt out."
       else

--- a/scripts/greeting.coffee
+++ b/scripts/greeting.coffee
@@ -19,14 +19,14 @@ module.exports = (robot) ->
   # greeting message sent to users
   greeting_msg = "Hello! Welcome to #terasology!\n" +
                  "This channel is in Moderated mode, where only voiced members can talk. This is because of a large amount of spam affecting the channel.\n" +
-                 "!!If you are not a robot then PM any operator to get voice!!\n" +
                  "Alternatively, visit our Discord at http://discord.gg/Terasology\n" +
                  "We will try our best to respond to your messages as soon as possible, please be patient " +
                  "and understand that not every online user will be watching the chat all the time.\n" +
-                 "Do check out https://github.com/MovingBlocks/Terasology/wiki/Using-IRC for more details about our IRC channel.\n" +
+                 "Do check out https://github.com/MovingBlocks/Terasology/wiki/Using-IRC for more details about our IRC channel." +
+                 "Alternatively, visit our Discord at http://discord.gg/Terasology\n" +
                  "If you would like to learn more about Terasology, be sure to visit http://forum.terasology.org for our forums " +
                  "and http://github.com/MovingBlocks/Terasology for our Github repo!\n"
-  understood_msg = "Reply 'Understood' to gain voice. You will not receive this greeting again."
+  understood_msg = "Reply 'Understood' to gain voice and speak in this channel. You will not receive this greeting again."
 
   robot.respond /understood.*/i, (msg) ->
     opt_out = JSON.parse(robot.brain.get 'greeting') or []
@@ -38,6 +38,7 @@ module.exports = (robot) ->
         robot.brain.set('greeting', JSON.stringify(opt_out))
         robot.brain.save()
         robot.adapter.command('MODE', main_bot_room, '+v', username)
+        robot.adapter.command('PRIVMSG', "ChanServ", ":FLAGS", main_bot_room, username, '+v')
         msg.send "You have been given voice and will not receive this greeting anymore. Message 'Reset Greeting' to me in private if you would like to undo this."
       else if guest_nick.test(username)
         msg.send "Guest accounts cannot opt out."


### PR DESCRIPTION
Attempts to fix #47. But instead of having a 'text captcha' as part of the greeting message, the bot will autovoice anyone who is able to reply to the message correctly, both temporarily (for those unregistered) and flagging them so they will be autovoiced automatically in the future (for those with registered nicknames).

From what I observed sitting the IRC, most of the bots are automated so this should be sufficient to ward off the spam that's coming in.