### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ So now:
 * Login to Heroku: `heroku login` - you should be prompted for your account info
 * Create a Heroku application: `heroku create [name]` replacing `[name]` with the app's name in all lower case letters, numbers, or dashes
 * Connect the remote Heroku application to your local Git repository: `heroku git:remote -a [name]` where again `[name]` matches what you named your app on Heroku
-* Push this to heroku by entering `git push heroku master`
+* Push this to heroku by entering `git push heroku develop:master`
 
 Once you've done this, you can now configure the bot by first giving it a nickname that will be displayed on IRC:
 
@@ -44,4 +44,6 @@ Unlike Espernet, Freenode requires SASL authentication for any user connecting f
 
 `heroku config:add HUBOT_IRC_USESASL="true"`  
 `heroku config:add HUBOT_IRC_USERNAME="YOUR_USERNAME"`  
-`heroku config:add HUBOT_IRC_PASSWORD="YOUR_PASSWORD"`  
+`heroku config:add HUBOT_IRC_PASSWORD="YOUR_PASSWORD"` 
+
+Note: Ensure that `HUBOT_IRC_NICK` is set to the same nickname used to register for your freenode account i.e. `HUBOT_IRC_NICK` should be the same as `HUBOT_IRC_USERNAME`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ So now:
 
 * Navigate to the GooeyJr repository that you have just cloned
 * Login to Heroku: `heroku login` - you should be prompted for your account info
-* Create a Heroku application: `heroku create [name] --stack cedar` replace `[name]` with the app's name in all lower case letters, numbers, or dashes
+* Create a Heroku application: `heroku create [name]` replacing `[name]` with the app's name in all lower case letters, numbers, or dashes
 * Connect the remote Heroku application to your local Git repository: `heroku git:remote -a [name]` where again `[name]` matches what you named your app on Heroku
 * Push this to heroku by entering `git push heroku master`
 
@@ -26,7 +26,7 @@ Once you've done this, you can now configure the bot by first giving it a nickna
 * Type: `heroku config:add HUBOT_IRC_NICK="GooeyJr"`, replacing "GooeyJr" with the nickname you would like the bot to have
   * You probably want to pick a name variant, such as adding your nick to the end of the bot name so that users can see whose bot it is. Take note that there is a limit of 16 characters.
 * Configure the IRC channel it connects to by entering: `heroku config:add HUBOT_IRC_ROOMS="#terasology"` 
-* Lastly, enter `heroku config:add HUBOT_IRC_SERVER="irc.esper.net"` so the bot connects to the Freenode server
+* Lastly, enter `heroku config:add HUBOT_IRC_SERVER="irc.esper.net"` so the bot connects to the Espernet server
 
 It should automatically start after you have entered the above commands (there might be a slight delay), but if not try: `heroku ps:scale web=1`.
  


### PR DESCRIPTION
- Removes mention of the deprecated cedar stack when creating the Heroku application through heroku-cli. Heroku will default to the latest stack.
- Typo fixes